### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For detailed information about how to configure and use Capistrano for deploymen
 7. Push to the branch (`git push origin my-new-feature`)
 8. Create new Pull Request
 
-##Getting your development environment to work
+## Getting your development environment to work
 
 1. You're going to need a working sshd server in your localhost, and access for your
    development user without password.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
